### PR TITLE
feat: introduce `messages`, `serviceMessages` and `error` streams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
 				"local-web-server": "^5.4.0",
 				"npm-run-all": "^4.1.5",
 				"prettier": "^3.5.0",
+				"rxjs": "^7.8.2",
 				"ts-jest": "~29.1.2",
 				"ts-node": "^10.9.2",
 				"typedoc": "^0.27.7",
@@ -104,6 +105,16 @@
 				"node": "^18.19.1 || ^20.11.1 || >=22.0.0",
 				"npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
 				"yarn": ">= 1.13.0"
+			}
+		},
+		"node_modules/@angular-devkit/architect/node_modules/rxjs": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.1.0"
 			}
 		},
 		"node_modules/@angular-devkit/build-angular": {
@@ -232,6 +243,16 @@
 				}
 			}
 		},
+		"node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
 		"node_modules/@angular-devkit/build-webpack": {
 			"version": "0.1901.7",
 			"resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1901.7.tgz",
@@ -250,6 +271,16 @@
 			"peerDependencies": {
 				"webpack": "^5.30.0",
 				"webpack-dev-server": "^5.0.2"
+			}
+		},
+		"node_modules/@angular-devkit/build-webpack/node_modules/rxjs": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.1.0"
 			}
 		},
 		"node_modules/@angular-devkit/core": {
@@ -280,6 +311,16 @@
 				}
 			}
 		},
+		"node_modules/@angular-devkit/core/node_modules/rxjs": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
 		"node_modules/@angular-devkit/schematics": {
 			"version": "19.1.7",
 			"resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.1.7.tgz",
@@ -297,6 +338,16 @@
 				"node": "^18.19.1 || ^20.11.1 || >=22.0.0",
 				"npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
 				"yarn": ">= 1.13.0"
+			}
+		},
+		"node_modules/@angular-devkit/schematics/node_modules/rxjs": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.1.0"
 			}
 		},
 		"node_modules/@angular-eslint/builder": {
@@ -19928,9 +19979,9 @@
 			}
 		},
 		"node_modules/rxjs": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-			"integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
 		"local-web-server": "^5.4.0",
 		"npm-run-all": "^4.1.5",
 		"prettier": "^3.5.0",
+		"rxjs": "^7.8.2",
 		"ts-jest": "~29.1.2",
 		"ts-node": "^10.9.2",
 		"typedoc": "^0.27.7",

--- a/packages/angular/lib/src/message-peer.service.spec.ts
+++ b/packages/angular/lib/src/message-peer.service.spec.ts
@@ -93,23 +93,27 @@ describe('MessagePeerService Interactions', () => {
 		jest.restoreAllMocks();
 	});
 
-	test('should connect and exchange messages', () => {
+	test('should connect and exchange messages and errors', () => {
 		const messages: any[] = [];
 		const serviceMessages: any[] = [];
+		const errors: any[] = [];
 		s2.messages$.subscribe(({ payload }) =>
 			messages.push({ type: payload.type, version: payload.version }),
 		);
 		s2.serviceMessages$.subscribe(({ payload }) =>
 			serviceMessages.push({ type: payload.type, version: payload.version }),
 		);
+		s2.errors$.subscribe((error) => errors.push(error.message));
 
 		s1.listen('s2');
 		s2.connect('s1');
 
 		s1.send({ type: 'test', version: '1.0' });
+		s1.send({ type: 'test', version: '2.0' });
 
 		expect(messages).toEqual([{ type: 'test', version: '1.0' }]);
 		expect(serviceMessages).toEqual([{ type: 'connect', version: '1.0' }]);
+		expect(errors).toEqual(['Unknown message version "2.0". Known versions: ["1.0"]']);
 	});
 });
 

--- a/packages/core-e2e/cases/handshake/index.html
+++ b/packages/core-e2e/cases/handshake/index.html
@@ -45,11 +45,11 @@
 	// 0. no iframe
 	const host = new MessagePeer({
 		id: 'host',
-		onMessage: (m) => {
-			const messages = document.getElementById('messages');
-			messages.innerHTML += `<div id="${m.from}">${m.from}</div>`;
-		},
 		knownMessages,
+	});
+	host.messages.subscribe((m) => {
+		const messages = document.getElementById('messages');
+		messages.innerHTML += `<div id="${m.from}">${m.from}</div>`;
 	});
 	host.listen('client-0');
 	host.send(

--- a/packages/core-e2e/cases/switch-connection/client-0.html
+++ b/packages/core-e2e/cases/switch-connection/client-0.html
@@ -15,10 +15,11 @@
 
 	const client = new MessagePeer({
 		id: 'client-0',
-		onMessage,
-		onServiceMessage: onMessage,
 		knownMessages,
 	});
+
+	client.messages.subscribe(onMessage);
+	client.serviceMessages.subscribe(onMessage);
 
 	client.connect('host', {
 		window: window.parent,

--- a/packages/core-e2e/cases/switch-connection/client-1.html
+++ b/packages/core-e2e/cases/switch-connection/client-1.html
@@ -15,10 +15,11 @@
 
 	const client = new MessagePeer({
 		id: 'client-1',
-		onMessage,
-		onServiceMessage: onMessage,
 		knownMessages,
 	});
+
+	client.messages.subscribe(onMessage);
+	client.serviceMessages.subscribe(onMessage);
 
 	client.connect('host', {
 		window: window.parent,

--- a/packages/core-e2e/cases/switch-connection/index.html
+++ b/packages/core-e2e/cases/switch-connection/index.html
@@ -60,10 +60,11 @@
 	// create host peer
 	const host = new MessagePeer({
 		id: 'host',
-		onMessage,
-		onServiceMessage: onMessage,
 		knownMessages,
 	});
+
+	host.messages.subscribe(onMessage);
+	host.serviceMessages.subscribe(onMessage);
 
 	// create client-0 at init
 	createClient('client-0', 'http://localhost:8092');

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -28,13 +28,7 @@ const peer = new MessagePeer({
   // unique identifier for this peer in the network
   id: 'one',
 
-  // callback to handle incoming messages
-  onMessage: (message) => {},
-
-  // handle service messages like `connect`, `disconnect`, etc.
-  onServiceMessage: (message) => {},
-
-  // list of messages this peer accepts after creation
+  // list of messages this peer accepts
   knownMessages: [
     { type: 'hello', version: '1.0' },
     { type: 'hello', version: '2.0' },
@@ -43,6 +37,8 @@ const peer = new MessagePeer({
 ```
 
 ### Connection to another peers
+
+A peer can either wait for incoming connections from a peer via `.listen()` or initiate a connection via `.connect()`.
 
 ```ts
 import { MessagePeer } from '@amadeus-it-group/microfrontends';
@@ -90,26 +86,26 @@ interface HelloMessage_2_0 extends Message {
 export type MyMessage = HelloMessage_1_0 | HelloMessage_2_0;
 ```
 
-### Sending messages
+### Sending and receiving messages
 
 ```ts
 import { MessagePeer } from '@amadeus-it-group/microfrontends';
 
 // Receiving messages
-const one = new MessagePeer<MyMessage>({
-  id: 'one',
-  onMessage: ({ payload }: MyMessage) => {
-    if (payload.type === 'hello') {
-      switch (payload.version) {
-        case '1.0':
-          console.log(payload.greeting); // string
-          break;
-        case '2.0':
-          console.log(payload.greetings); // string[]
-          break;
-      }
+const one = new MessagePeer<MyMessage>({ id: 'one' });
+
+// An observable-like interface consuming messages
+one.messages.subscribe(({ payload }: MyMessage) => {
+  if (payload.type === 'hello') {
+    switch (payload.version) {
+      case '1.0':
+        console.log(payload.greeting); // string
+        break;
+      case '2.0':
+        console.log(payload.greetings); // string[]
+        break;
     }
-  },
+  }
 });
 
 // Broadcast a message. Message will be type checked.

--- a/packages/core/src/checks.ts
+++ b/packages/core/src/checks.ts
@@ -15,9 +15,9 @@ export interface MessageCheck<M extends Message> {
  * @param message Message to check
  * @param peer Endpoint that processes the message
  */
-export function checkMessageIsKnown(
-	message: RoutedMessage<Message>,
-	peer: MessagePeerType<Message>,
+export function checkMessageIsKnown<M extends Message>(
+	message: RoutedMessage<M>,
+	peer: MessagePeerType<M>,
 ) {
 	const knownMessages = peer.knownPeers.get(peer.id);
 	const { payload } = message;
@@ -35,9 +35,9 @@ export function checkMessageIsKnown(
  * @param message Message to check
  * @param peer Endpoint that processes the message
  */
-export function checkMessageVersionIsKnown(
-	message: RoutedMessage<Message>,
-	peer: MessagePeerType<Message>,
+export function checkMessageVersionIsKnown<M extends Message>(
+	message: RoutedMessage<M>,
+	peer: MessagePeerType<M>,
 ) {
 	const knownMessages = peer.knownPeers.get(peer.id);
 	const { payload } = message;
@@ -60,13 +60,15 @@ export function checkMessageVersionIsKnown(
 /**
  * Default message checks that peer performs on incoming messages
  */
-export const PEER_MESSAGE_CHECKS: MessageCheck<Message>[] = [
-	{
-		description: 'Check that message is known',
-		check: checkMessageIsKnown,
-	},
-	{
-		description: 'Check that message version is known',
-		check: checkMessageVersionIsKnown,
-	},
-];
+export function defaultMessageChecks<M extends Message>(): MessageCheck<M>[] {
+	return [
+		{
+			description: 'Check that message is known',
+			check: checkMessageIsKnown,
+		},
+		{
+			description: 'Check that message version is known',
+			check: checkMessageVersionIsKnown,
+		},
+	];
+}

--- a/packages/core/src/emitter.spec.ts
+++ b/packages/core/src/emitter.spec.ts
@@ -1,0 +1,45 @@
+import { Emitter } from './emitter';
+
+describe(`Emitter`, () => {
+	test(`should emit values`, () => {
+		const emitter = new Emitter<number>();
+
+		const values: number[] = [];
+		emitter.subscribe((v) => values.push(v)); // function
+		emitter.subscribe({ next: (v) => values.push(v * 2) }); // subscriber object
+		expect(values).toEqual([]);
+
+		emitter.emit(2);
+
+		expect(values).toEqual([2, 4]);
+	});
+
+	test(`should not emit values to unsubscribed subscribers`, () => {
+		const emitter = new Emitter<number>();
+
+		const values: number[] = [];
+		emitter.subscribe((v) => values.push(v));
+		const unsub = emitter.subscribe((v) => values.push(v * 2));
+		expect(values).toEqual([]);
+
+		emitter.emit(2);
+		expect(values).toEqual([2, 4]);
+
+		unsub.unsubscribe();
+		emitter.emit(10);
+		expect(values).toEqual([2, 4, 10]);
+	});
+
+	test(`should ignore nullable values`, () => {
+		const emitter = new Emitter<number>();
+
+		const values: number[] = [];
+		emitter.subscribe((v) => values.push(v));
+		emitter.subscribe((v) => values.push(v * 2));
+		expect(values).toEqual([]);
+
+		emitter.emit(2);
+
+		expect(values).toEqual([2, 4]);
+	});
+});

--- a/packages/core/src/emitter.ts
+++ b/packages/core/src/emitter.ts
@@ -1,0 +1,80 @@
+declare global {
+	interface SymbolConstructor {
+		readonly observable: symbol;
+	}
+}
+
+export type SubscriberFunction<T> = (value: T) => void;
+
+export interface SubscriberObject<T> {
+	next?: SubscriberFunction<T>;
+}
+
+export type Subscriber<T> = SubscriberObject<T> | SubscriberFunction<T> | null | undefined;
+
+interface Subscription {
+	unsubscribe(): void;
+}
+
+/**
+ * An Observable-compatible interface for consuming messages.
+ *
+ * It can also be used with rxjs, for example:
+ *
+ * ```ts
+ * import { from } from 'rxjs';
+ *
+ * const peer = new MessagePeer({...});
+ * const observable = from(peer.messages);
+ * ```
+ */
+export interface Subscribable<T> {
+	[Symbol.observable](): Subscribable<T>;
+
+	subscribe(subscriber: Subscriber<T>): Subscription;
+}
+
+const EMPTY_SUBSCRIPTION: Subscription = {
+	unsubscribe: () => {
+		// do nothing
+	},
+};
+
+export class Emitter<T> implements Subscribable<T> {
+	#subscribers = new Set<NonNullable<Subscriber<T>>>();
+
+	get subscribers() {
+		return this.#subscribers;
+	}
+
+	subscribe(subscriber: Subscriber<T>): Subscription {
+		if (subscriber) {
+			this.#subscribers.add(subscriber);
+			return {
+				unsubscribe: () => {
+					this.#subscribers.delete(subscriber);
+				},
+			};
+		} else {
+			return EMPTY_SUBSCRIPTION;
+		}
+	}
+
+	emit(value: T): void {
+		for (const subscriber of this.#subscribers) {
+			if (typeof subscriber === 'function') {
+				subscriber(value);
+			} else {
+				subscriber.next?.(value);
+			}
+		}
+	}
+
+	[Symbol.observable](): Subscribable<T> {
+		return this;
+	}
+
+	['@@observable'](): Subscribable<T> {
+		return this;
+	}
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,3 +11,4 @@ export { MessagePeer } from './peer';
 export type { MessagePeerType, PeerConnectionOptions, PeerOptions, PeerSendOptions } from './peer';
 export { MessageError } from './message-error';
 export { enableLogging } from './utils';
+export type { Subscribable } from './emitter';


### PR DESCRIPTION
Introduce new APIs for message consumptions. It will make it easier to dissociate peer creation with and places where messages might be consumed. It also uses Obsevable- and rxjs-compatible implementation for streams of messages.

**BREAKING CHANGE:**

No longer possible to get messages via `onMessage`, `onServiceMessage` and `onError`at construction time, one should use`.messages`, `.serviceMessages` and `.errors` subscribable streams:

```ts
// BEFORE
const peer = new MessagePeer({
  id: 'one',
  onMessage: (m) => {},
  onServiceMessage: (m) => {},
  onError: (e) => {}
});

// AFTER
const peer = new MessagePeer({ id: 'one' });

peer.messages.subscribe(m => {});
peer.serviceMessages.subscribe(m => {});
peer.errors.subscribe(e => {})
```